### PR TITLE
Add LICENSE file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md
+include README.md LICENSE


### PR DESCRIPTION
This is required when a banal`wheel` is built.
At the moment we get:
```
  running install_egg_info
  Copying banal.egg-info to build/bdist.linux-x86_64/wheel/banal-0.3.5-py3.6.egg-info
  running install_scripts
  error: [Errno 2] No such file or directory: 'LICENSE'
```